### PR TITLE
add link to forum on header

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -24,10 +24,10 @@ theme = "hugo-bootstrap"
   weight = 13
   url = "/"
 
-  [[languages.pt.menu.main]]
-    url = "/"
-    name = "Home"
-    weight = 1
+   [[languages.pt.menu.main]]
+     url = "https://cafe.privacylx.org"
+     name = "Comunidade"
+     weight = 1
   [[languages.pt.menu.main]]
     url = "/events/"
     name = "Eventos"
@@ -42,10 +42,10 @@ theme = "hugo-bootstrap"
   weight = 1
   url = "/en/"
 
-  [[languages.en.menu.main]]
-    url = "/en/"
-    name = "Home"
-    weight = 1
+   [[languages.en.menu.main]]
+     url = "https://cafe.privacylx.org"
+     name = "Community"
+     weight = 1
   [[languages.en.menu.main]]
     url = "/events/"
     name = "Events"


### PR DESCRIPTION
Once the forum is ready, we can merge this

![Screenshot-2019-6-17 Privacy Lx](https://user-images.githubusercontent.com/32313429/59637809-38e85800-9146-11e9-983e-5f281903339f.png)

What do you prefer for the forum link @anadahz @kcg295?
  - `Forum`
  - `Community`
  - `Cafe` (people might not understand that is the link to the forum)