### PR TITLE
Add options to exclude page from sitemap and RSS feed

### DIFF
--- a/content/events/Brevemente.en.md
+++ b/content/events/Brevemente.en.md
@@ -7,6 +7,8 @@ image: "/img/computer.png"
 hidedate: true
 preview: true
 description: "Keep checking to our website because we are preparing future workshops. If you would be interested in hosting or helping with one, let us know. For contacts click on 'read more'"
+sitemap_exclude: true
+rss_exclude: true
 ---
 
 We would like to thank all the people who filled the rooms of our last events and let you know that we are preparing future events.

--- a/content/events/Brevemente.pt.md
+++ b/content/events/Brevemente.pt.md
@@ -8,6 +8,8 @@ hidedate: true
 preview: true
 description: "Obrigado a todas as pessoas que participaram nos eventos este ano e contribuiram para fascinantes discussões. Estejam atentos ao website pois estamos a preparar futuros eventos. Se tiverem interesse nestes tópicos, entrem em contacto connosco."
 draft: false
+sitemap_exclude: true
+rss_exclude: true
 ---
 
 Queriamos aproveitar para agradecer a todos os participantes das úlimas sessões que encheram a sala e deixar desde já a mensagem que mais eventos virão. Portanto estejam atentos às novidades neste site.

--- a/layouts/_default/rss.xml
+++ b/layouts/_default/rss.xml
@@ -1,4 +1,3 @@
-{{ printf "<?xml version=\"1.0\" encoding=\"utf-8\" standalone=\"yes\" ?>" | safeHTML }}
 <rss version="2.0" xmlns:atom="http://www.w3.org/2005/Atom">
   <channel>
     <title>{{ if eq  .Title  .Site.Title }}{{ .Site.Title }}{{ else }}{{ with .Title }}{{.}} on {{ end }}{{ .Site.Title }}{{ end }}</title>

--- a/layouts/_default/rss.xml
+++ b/layouts/_default/rss.xml
@@ -1,0 +1,27 @@
+{{ printf "<?xml version=\"1.0\" encoding=\"utf-8\" standalone=\"yes\" ?>" | safeHTML }}
+<rss version="2.0" xmlns:atom="http://www.w3.org/2005/Atom">
+  <channel>
+    <title>{{ if eq  .Title  .Site.Title }}{{ .Site.Title }}{{ else }}{{ with .Title }}{{.}} on {{ end }}{{ .Site.Title }}{{ end }}</title>
+    <link>{{ .Permalink }}</link>
+    <description>Recent content {{ if ne  .Title  .Site.Title }}{{ with .Title }}in {{.}} {{ end }}{{ end }}on {{ .Site.Title }}</description>
+    <generator>Hugo -- gohugo.io</generator>{{ with .Site.LanguageCode }}
+    <language>{{.}}</language>{{end}}{{ with .Site.Author.email }}
+    <managingEditor>{{.}}{{ with $.Site.Author.name }} ({{.}}){{end}}</managingEditor>{{end}}{{ with .Site.Author.email }}
+    <webMaster>{{.}}{{ with $.Site.Author.name }} ({{.}}){{end}}</webMaster>{{end}}{{ with .Site.Copyright }}
+    <copyright>{{.}}</copyright>{{end}}{{ if not .Date.IsZero }}
+    <lastBuildDate>{{ .Date.Format "Mon, 02 Jan 2006 15:04:05 -0700" | safeHTML }}</lastBuildDate>{{ end }}
+    {{ with .OutputFormats.Get "RSS" }}
+        {{ printf "<atom:link href=%q rel=\"self\" type=%q />" .Permalink .MediaType | safeHTML }}
+    {{ end }}
+    {{ range .Data.Pages }}{{ if ne .Params.rss_exclude true }}
+    <item>
+      <title>{{ .Title }}</title>
+      <link>{{ .Permalink }}</link>
+      <pubDate>{{ .Date.Format "Mon, 02 Jan 2006 15:04:05 -0700" | safeHTML }}</pubDate>
+      {{ with .Site.Author.email }}<author>{{.}}{{ with $.Site.Author.name }} ({{.}}){{end}}</author>{{end}}
+      <guid>{{ .Permalink }}</guid>
+      <description>{{ .Summary | html }}</description>
+    </item>
+    {{ end }}{{ end }}
+  </channel>
+</rss>

--- a/layouts/_default/sitemap.xml
+++ b/layouts/_default/sitemap.xml
@@ -1,0 +1,22 @@
+{{ printf "<?xml version=\"1.0\" encoding=\"utf-8\" standalone=\"yes\" ?>" | safeHTML }}
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9"
+  xmlns:xhtml="http://www.w3.org/1999/xhtml">
+  {{ range .Data.Pages }}{{ if ne .Params.sitemap_exclude true }}
+  <url>
+    <loc>{{ .Permalink }}</loc>{{ if not .Lastmod.IsZero }}
+    <lastmod>{{ safeHTML ( .Lastmod.Format "2006-01-02T15:04:05-07:00" ) }}</lastmod>{{ end }}{{ with .Sitemap.ChangeFreq }}
+    <changefreq>{{ . }}</changefreq>{{ end }}{{ if ge .Sitemap.Priority 0.0 }}
+    <priority>{{ .Sitemap.Priority }}</priority>{{ end }}{{ if .IsTranslated }}{{ range .Translations }}
+    <xhtml:link
+                rel="alternate"
+                hreflang="{{ .Lang }}"
+                href="{{ .Permalink }}"
+                />{{ end }}
+    <xhtml:link
+                rel="alternate"
+                hreflang="{{ .Lang }}"
+                href="{{ .Permalink }}"
+                />{{ end }}
+  </url>
+  {{ end }}{{ end }}
+</urlset>

--- a/layouts/_default/sitemap.xml
+++ b/layouts/_default/sitemap.xml
@@ -1,4 +1,3 @@
-{{ printf "<?xml version=\"1.0\" encoding=\"utf-8\" standalone=\"yes\" ?>" | safeHTML }}
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9"
   xmlns:xhtml="http://www.w3.org/1999/xhtml">
   {{ range .Data.Pages }}{{ if ne .Params.sitemap_exclude true }}


### PR DESCRIPTION
This commit fixes:
https://github.com/PrivacyLx/privacylx-issue-tracker/issues/39

It add support to exclude pages from sitemap and RSS by using the
variables `sitemap_exclude: true` and `rss_exclude: true` to front
matter accordingly.