### PR TITLE
Discourse shortcode

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,14 @@ For that, in the website root directory you type `hugo new content/events/[name-
 just copy and paste some content's markdown from the type of
 content that you want in order to add it.
 
+### Adding forum comments to post / blog
+
+There is the option to add the discourse comments to the post. For
+that you can add "{{< discourse-comments >}}" in the bottom of your
+markdown post and it should show up on the website. (But it will only
+work on a live deployment).
+
+
 ### Adding images and presentations
 All static content goes under `/static/` and is is referenced as though it was in the root of the website.
 

--- a/config.toml
+++ b/config.toml
@@ -77,6 +77,9 @@ theme = "hugo-bootstrap"
   # Default author
   author = "Anonymous"
 
+  # Our dicourse forum URL
+  discourse_forum = "https://cafe.privacylx.org/"
+
   ghrepo = "https://github.com/PrivacyLx/website/"
 
   # Onion service URLs

--- a/content/post/toca-do-coelho-ave-rara.pt.md
+++ b/content/post/toca-do-coelho-ave-rara.pt.md
@@ -100,3 +100,4 @@ Remato com uma frase que dá o nome a este guia e que vos é a todos familiar, d
 
 9 - Source (Matrix movie): «After this, there is no turning back. You take the blue pill the story ends, you wake up in your bed and believe whatever you want to believe. You take the red pill you stay in Wonderland, and I show you how deep the rabbit hole goes. Remember: all I'm offering is the truth. Nothing more. »
 
+{{< discourse-comments >}}

--- a/layouts/shortcodes/discourse-comments.html
+++ b/layouts/shortcodes/discourse-comments.html
@@ -1,0 +1,12 @@
+<div id='discourse-comments'></div>
+
+<script type="text/javascript">
+  DiscourseEmbed = { discourseUrl: 'https://cafe.privacylx.org/',
+                     discourseEmbedUrl: {{ $.Page.Permalink }} };
+
+  (function() {
+    var d = document.createElement('script'); d.type = 'text/javascript'; d.async = true;
+    d.src = DiscourseEmbed.discourseUrl + 'javascripts/embed.js';
+    (document.getElementsByTagName('head')[0] || document.getElementsByTagName('body')[0]).appendChild(d);
+  })();
+</script>

--- a/layouts/shortcodes/discourse-comments.html
+++ b/layouts/shortcodes/discourse-comments.html
@@ -1,7 +1,7 @@
 <div id='discourse-comments'></div>
 
 <script type="text/javascript">
-  DiscourseEmbed = { discourseUrl: 'https://cafe.privacylx.org/',
+  DiscourseEmbed = { discourseUrl: {{ $.Site.Params.discourse_forum }},
                      discourseEmbedUrl: {{ $.Page.Permalink }} };
 
   (function() {


### PR DESCRIPTION
Implemented [embedding discourse comments](https://meta.discourse.org/t/embedding-discourse-comments-via-javascript/31963) on our website.

- Create [hugo shortcode](https://gohugo.io/templates/shortcode-templates/) for embedding discourse discussions to a post.
- If the post on the forum does not exist already, it will create it - which should be a good thing (we don't have to mirror content) 
- Add forum discussion of our first post in the series "Descendo a toca do coelho".
- added our website to the accepted hosts to have embedded comments. See image bellow

**Note:** there is no real way to test this unless used right into production because it must authenticate the domain. So I suggest we just merge this.

![embed-posts](https://user-images.githubusercontent.com/32313429/86370761-a4c53200-bc6f-11ea-8399-ac7ad2d803f8.png)


## How to use this

To add this to a blog you need to add `{{< discourse-comments >}}` to the end of that blog.

## Future work

In the future if we want to expand to every post without having to do it manually with the shortcode, we may implement it as a partial.
