### PR TITLE
Append the path of active page in Onion-Location header

### DIFF
--- a/themes/hugo-bootstrap/layouts/partials/head-meta.html
+++ b/themes/hugo-bootstrap/layouts/partials/head-meta.html
@@ -2,7 +2,7 @@
 <meta http-equiv="x-ua-compatible" content="ie=edge">
 <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
 {{if isset .Site.Params "onionv3"}}
-<meta http-equiv="onion-location" content="{{ .Site.Params.onionv3 }}" />
+<meta http-equiv="onion-location" content="{{ .Site.Params.onionv3 }}{{ .URL }}">
 {{ end }}
 
 {{ template "_internal/opengraph.html" . }}


### PR DESCRIPTION
Users are now on the current page and not on the home page as it was
previously the case.