### PR TITLE
become a member on header

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -35,12 +35,12 @@ theme = "hugo-bootstrap"
     name = "Comunidade"
     weight = 3
   [[languages.pt.menu.main]]
-    url = "https://bbb.privacylx.org"
-    name = "Videoconferências"
-    weight = 4
-  [[languages.pt.menu.main]]
     url = "/resources/"
     name = "Slides"
+    weight = 4
+  [[languages.pt.menu.main]]
+    url = "/community/become-a-member"
+    name = "Associa-te!"
     weight = 5
 [languages.en]
   languageName = "English"
@@ -58,13 +58,13 @@ theme = "hugo-bootstrap"
     url = "/community/"
     name = "Community"
     weight = 3
- [[languages.en.menu.main]]
-    url = "https://bbb.privacylx.org"
-    name = "Videoconferences"
-    weight = 4
   [[languages.en.menu.main]]
     url = "/resources/"
     name = "Slides"
+    weight = 4
+  [[languages.en.menu.main]]
+    url = "/community/become-a-member"
+    name = "Become a member!"
     weight = 5
 
 [permalinks]

--- a/themes/hugo-bootstrap/layouts/partials/header.html
+++ b/themes/hugo-bootstrap/layouts/partials/header.html
@@ -11,7 +11,7 @@
             <ul class="navbar-nav">
               {{ $url := .URL | relLangURL }}
               {{ range .Site.Menus.main }}
-                {{ if eq (.URL ) "/post/" }} <!-- Make blog be a button -->
+                {{ if eq (.URL ) "/community/become-a-member" }} <!-- Make blog be a button -->
                 <h5> </h5>
                 <a class="btn btn-info " href="{{ .URL | relLangURL }}">{{ .Name }}</a>
                 {{ else }}


### PR DESCRIPTION
Per suggestion, made more visible the option for people to become a member of the association.

## Before
![Screen Shot 2021-01-13 at 17 55 48](https://user-images.githubusercontent.com/32313429/104490464-c90fad00-55c8-11eb-9747-756af543188e.png)

## After
![Screen Shot 2021-01-13 at 17 54 16](https://user-images.githubusercontent.com/32313429/104490472-cb720700-55c8-11eb-8125-d600af076f9e.png)

I had to ditch the BBB link (which is still in the footer)

